### PR TITLE
fix: resign dylibs for all mac systems (not just arm)

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -37,11 +37,14 @@ class SmithyCli < Formula
     def post_install
         # brew relocates dylibs and assigns different ids, which is problematic since
         # we package a runtime image ourselves
-        Dir["#{libexec}/**/*.dylib"].each do |dylib|
-            chmod 0664, dylib
-            MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
-            MachO.codesign!(dylib) if Hardware::CPU.arm?
-            chmod 0444, dylib
+        if OS.mac?
+            Dir["#{libexec}/lib/**/*.dylib"].each do |dylib|
+                chmod 0664, dylib
+                MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
+                # we also need to resign the dylibs, so that their ad-hoc signatures are not invalid
+                MachO.codesign!(dylib)
+                chmod 0444, dylib
+            end
         end
         # call warmup command to generate the jsa 
         system "#{bin}/#{$config_provider.bin}" " warmup"


### PR DESCRIPTION
*Description of changes:*
- Similar to this [fix for ARM](https://github.com/aws/homebrew-tap/pull/454), the cli now fails to install correctly on intel-based Mac's (Ventura 13.4 (22F66))
- This change forces re-signing the dylibs for mac (not just arm)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
