### PR TITLE
Switch to zips instead of tarballs

### DIFF
--- a/Formula/smithy-cli.rb
+++ b/Formula/smithy-cli.rb
@@ -9,18 +9,18 @@ class SmithyCli < Formula
 
     if OS.mac?
       if Hardware::CPU.intel?
-        url "#{$config_provider.root_url}-darwin-x86_64.tar.gz"
+        url "#{$config_provider.root_url}-darwin-x86_64.zip"
         sha256 $config_provider.sierra_hash
       elsif Hardware::CPU.arm?
-        url "#{$config_provider.root_url}-darwin-aarch64.tar.gz"
+        url "#{$config_provider.root_url}-darwin-aarch64.zip"
         sha256 $config_provider.arm64_big_sur_hash
       end
     elsif OS.linux?
       if Hardware::CPU.intel?
-        url "#{$config_provider.root_url}-linux-x86_64.tar.gz"
+        url "#{$config_provider.root_url}-linux-x86_64.zip"
         sha256 $config_provider.linux_hash
       elsif Hardware::CPU.arm?
-        url "#{$config_provider.root_url}-linux-aarch64.tar.gz"
+        url "#{$config_provider.root_url}-linux-aarch64.zip"
         sha256 $config_provider.linux_arm_hash
       end
     end

--- a/bottle-configs/smithy-cli.json
+++ b/bottle-configs/smithy-cli.json
@@ -5,10 +5,10 @@
   "bottle": {
     "root_url": "https://github.com/smithy-lang/smithy/releases/download/1.47.0/smithy-cli",
     "sha256": {
-      "arm64_big_sur": "6249ba112b20fad442859fef343b5ca6ff3e042704093ab6f1b7d1682825137f",
-      "sierra": "095a02caf1d159c4b4abdc9406b1c947cca23700e7547737adaadb1c6a471c7d",
-      "linux": "7d07cc569c12c05b5f0c540eec44fb02116a5652d2720ca28558fd3d4c0ebfcf",
-      "linux_arm": "3154b5d73ff3b5360a2fbded4c522ee09184a5f7bae2ff3c04bbfde4149948f9"
+      "arm64_big_sur": "add7893a9d760ce634f1a256fda9eeff886e6416797aa0f5eddecc6aefd15ed6",
+      "sierra": "6e0eeac8f8a2d7a6379ab297b9b74c8c9bd806b32d79aba6826355055c468919",
+      "linux": "3cc7f2df9d8e0f3ea1bc8685c25fb75e4306f32188c653defb0ba6c3e974a91a",
+      "linux_arm": "f652d38609853154d663b6c74601b4d2cee853eaa80c4076415983e5a76c3a2b"
     }
   }
 }


### PR DESCRIPTION
*Description of changes:*
- Similar to the update to [smithy-asdf](https://github.com/smithy-lang/asdf-smithy/pull/4/), update config to use zips
- Unlike smithy-asdf, brew doesn't support versioning for taps, so there is no need for version checking for compatibility
- The updated hashes are taken from the 1.47.0 release (the zip files)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
